### PR TITLE
updated docs/index.html for redirect github repo url

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
     <script>
         window.$docsify = {
             name: "Chaki",
-            repo: "github.com/Trendyol/chaki",
+            repo: "Trendyol/chaki",
             loadSidebar: true, auto2top: true,
             subMaxLevel: 3, notFoundPage: true,
             themeColor: "#ff6961", search: "auto",


### PR DESCRIPTION
When you try to go to the repo, https://github.com/github.com/Trendyol/chaki is redirected here. https://docsify.js.org/#/configuration?id=repo was edited according to the configuration.