### PR TITLE
Fix/logger sync

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,6 +3,8 @@ package logger
 import (
 	"context"
 	"errors"
+	"io/fs"
+	"syscall"
 
 	"github.com/Trendyol/chaki/util/appctx"
 	"go.uber.org/zap"
@@ -45,7 +47,14 @@ func New() *zap.Logger {
 }
 
 func Sync() error {
-	return New().Sync()
+	err := New().Sync()
+
+	var pathErr *fs.PathError
+	if errors.Is(err, syscall.ENOTTY) || errors.As(err, &pathErr) {
+		return nil
+	}
+
+	return err
 }
 
 func From(ctx context.Context) *zap.Logger {

--- a/option.go
+++ b/option.go
@@ -5,14 +5,14 @@ import (
 )
 
 type configOptions struct {
-	disabled       bool
-	path           string
 	referencePaths map[string]string
+	path           string
+	disabled       bool
 }
 
 type options struct {
-	timeout       time.Duration
 	configOptions configOptions
+	timeout       time.Duration
 }
 
 func getOptions(opt ...Option) *options {


### PR DESCRIPTION
If logger.Sync() return an error, syscall.ENOTTY for UNIX, fs.PathError for Windows; ignore it.


See: 
- https://github.com/uber-go/zap/issues/991
- https://github.com/uber-go/zap/issues/880